### PR TITLE
Add KeyboardInterrupt handling

### DIFF
--- a/src/autocommand/autocommand.py
+++ b/src/autocommand/autocommand.py
@@ -16,7 +16,7 @@
 # along with autocommand.  If not, see <http://www.gnu.org/licenses/>.
 
 from .autoparse import autoparse
-from .automain import automain
+from .automain import automain  # noqa: F401
 try:
     from .autoasync import autoasync
 except ImportError:  # pragma: no cover
@@ -31,7 +31,12 @@ def autocommand(
         parser=None,
         loop=None,
         forever=False,
-        pass_loop=False):
+        pass_loop=False,
+        automain=None,  # noqa: F811
+        ):
+
+    # bind late to allow for monkeypatching in tests
+    automain = automain or globals()['automain']
 
     if callable(module):
         raise TypeError('autocommand requires a module name argument')

--- a/test/test_automain.py
+++ b/test/test_automain.py
@@ -66,3 +66,10 @@ def test_args_and_kwargs():
             assert b == 2
 
     assert main_called
+
+
+def test_keyboard_interrupt_ignored():
+    with pytest.raises(KeyboardInterrupt):
+        @automain(True)
+        def main():
+            raise KeyboardInterrupt()

--- a/test/test_automain.py
+++ b/test/test_automain.py
@@ -73,3 +73,26 @@ def test_keyboard_interrupt_ignored():
         @automain(True)
         def main():
             raise KeyboardInterrupt()
+
+
+def test_keyboard_interrupt_ignored_explicit():
+    with pytest.raises(KeyboardInterrupt):
+        @automain(True, on_interrupt='ignore')
+        def main():
+            raise KeyboardInterrupt()
+
+
+def test_keyboard_interrupt_quiet():
+    with pytest.raises(SystemExit) as ctx:
+        @automain(True, on_interrupt='quiet')
+        def main():
+            raise KeyboardInterrupt()
+    assert ctx.value.code == 1
+
+
+def test_keyboard_interrupt_suppress():
+    with pytest.raises(SystemExit) as ctx:
+        @automain(True, on_interrupt='suppress')
+        def main():
+            raise KeyboardInterrupt()
+    assert ctx.value.code == 0


### PR DESCRIPTION
I've started work on a patch for #18. In this PR, the `automain` accepts a new optional parameter `on_interrupt`, which can be `ignore` (the default and current behavior), `suppress` (suppress the exception and exit 0), or `quiet` (exit 1 without a traceback).

I ran into a bit of difficulty when trying to wire it into automain and especially when trying to wire that through autocommand. The current approach allows `autocommand` to accept a new `automain` parameter, overriding the default `automain`, such as with `autocommand(automain=functools.partial(autocommand.automain, on_interrupt='quiet'))`. I don't love that interface.

And now that I think about it more, I'm not sure having this functionality integrated with automain makes any sense at all, and maybe there should just be a new, independent decorator for interrupt handling.

Still, I'd like to submit this for your consideration - are there any behaviors from this approach that you'd like to see in the final approach?