### PR TITLE
Introduce github action for CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,6 +38,10 @@ jobs:
         if test -f test_requirements.txt; then pip install -r test_requirements.txt; fi
         if test -f requirements.txt; then pip install -r requirements.txt; fi
         
+    - name: Install autocommand
+      run: |
+        pip install -e .
+        
     - name: Test with pytest
       run: |
         python3 -m pytest --cov autocommand --cov-report term-missing --cov-config .coveragerc --strict test

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,4 +40,4 @@ jobs:
         
     - name: Test with pytest
       run: |
-        pytest
+        python3 -m pytest --cov autocommand --cov-report term-missing --cov-config .coveragerc --strict test

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,43 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{matrix.python_version}}
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f test_requirements.txt]; then pip install -r test_requirements.txt; fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f test_requirements.txt]; then pip install -r test_requirements.txt; fi
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if test -f test_requirements.txt; then pip install -r test_requirements.txt; fi
+        if test -f requirements.txt; then pip install -r requirements.txt; fi
         
     - name: Test with pytest
       run: |


### PR DESCRIPTION
We left travis ci ages ago; add a file for CI with github actions. Flake8 appears to be broken right now so we're disabling it for now (doesn't understand arbitrary python expressions in annotation position).