### PR TITLE
License is dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+dynamic = [ "license" ]
 
 [project.urls]
 "Homepage" = "https://github.com/Lucretiel/autocommand"


### PR DESCRIPTION
Setuptools 69 [enforces the correct use of PEP 621 for `project.dynamic`. ](https://setuptools.pypa.io/en/latest/history.html#deprecations-and-removals)

Fixes #28 