### PR TITLE
Remove license declaration and rely instead on Trove classifiers and LICENSE being included.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     ],
     package_dir={'': 'src'},
     platforms='any',
-    license='LGPLv3',
     author='Nathan West',
     url='https://github.com/Lucretiel/autocommand',
     description='A library to create a command-line program from a function',


### PR DESCRIPTION
Closes #32. Supersedes #31.
